### PR TITLE
formatting and styling consistency

### DIFF
--- a/lib/elCanvas.js
+++ b/lib/elCanvas.js
@@ -679,26 +679,25 @@ elCanvas = (function () {
 		styleShape: function (styles) {
 			this.ctx.setAll(styles);
 		},
-    maskShape: function (props) {
-      //render the object that is going to be the mask pre making the current object, but don't style it
-       if(!props.inverseMask){
-         this.draw(props.mask)
-         this.ctx.clip();
-       }else{
-         //for reverse masking blendingmodes need to be used since reverse pathing doesn't work on all occasions
-         props.globalCompositeOperation='destination-out';
-         props.mask.globalCompositeOperation='source-over';
-       }
-       this.draw(props.mask);
+		maskShape: function (props) {
+			//render the object that is going to be the mask pre making the current object, but don't style it
+			if (!props.inverseMask) {
+				this.draw(props.mask);
+				this.ctx.clip();
+			} else {
+				//for reverse masking blendingmodes need to be used since reverse pathing doesn't work on all occasions
+				props.globalCompositeOperation='destination-out';
+				props.mask.globalCompositeOperation='source-over';
+			}
+			this.draw(props.mask);
 		},
 		draw: function (props) {
-        this.ctx.save();
-        props.mask ? this.maskShape(props): false;
-  			this.prepareShape(props);
-  			this.styleShape(props.style);
-			  this.renderFuncs[props.type](this, props);
-      	this.ctx.restore();
-			// this.debugObject(props);
+			this.ctx.save();
+			props.mask && this.maskShape(props);
+			this.prepareShape(props);
+			this.styleShape(props.style);
+			this.renderFuncs[props.type](this, props);
+			this.ctx.restore();
 		},
 		debugObject: function (props) {
 			if (props.debug) {
@@ -714,15 +713,15 @@ elCanvas = (function () {
 					delete props.style['textBaseline'];
 				}
 			},
-      svg:function(props){
-        // setup the svg points on call not on update so we immediately know the points
-        //rebuild points only if the supplied are new points
-        props.__cachedFunction = _util.parseSvgPathData(props, el.ctx);
-        //add line dash if youve declared it in styles
-        props.style.setLineDash ? el.ctx.setLineDash(props.style.setLineDash.split(',').map(Number)) : false;
-        props.style.lineDashOffset ? el.ctx.set('lineDashOffset',props.style.lineDashOffset) : false;
-        props.__cachedFunction();
-      },
+			svg:function (props) {
+				// setup the svg points on call not on update so we immediately know the points
+				//rebuild points only if the supplied are new points
+				props.__cachedFunction = _util.parseSvgPathData(props, el.ctx);
+				//add line dash if youve declared it in styles
+				props.style.setLineDash && el.ctx.setLineDash(props.style.setLineDash.split(',').map(Number));
+				props.style.lineDashOffset && el.ctx.set('lineDashOffset', props.style.lineDashOffset);
+				props.__cachedFunction();
+			},
 			image: function (props) {
 				props.id = props.id || props.url;
 				if (!this.images[props.id]) {
@@ -734,7 +733,6 @@ elCanvas = (function () {
 						this.images[props.id] = _util.generateRadialGradientBitmap(props.id, props.radialGradient.size,
 							props.radialGradient.inner, props.radialGradient.outer);
 					}
-
 				}
 			},
 			textSprite: function (props) {
@@ -864,7 +862,8 @@ elCanvas = (function () {
 				if (!(image instanceof Image)) {
 					return;
 				}
-        !mask ?  el.ctx.fillAndStroke('empty', props.opacity): false;
+
+				(!mask) && el.ctx.fillAndStroke('empty', props.opacity);
 
 				if (props.sprite) {
 					// sprite image, copy only a part of the full image
@@ -879,10 +878,10 @@ elCanvas = (function () {
 
 					el.ctx.drawImage(image, 0, 0, props.width, props.height);
 				}
-      el.ctx.fillAndStroke(props.style, 'empty');
+				el.ctx.fillAndStroke(props.style, 'empty');
 			},
-			text: function (el, props){
-        el.ctx.fillAndStroke('empty', props.opacity);
+			text: function (el, props) {
+				el.ctx.fillAndStroke('empty', props.opacity);
 				var maxWidth = undefined;
 
 				if (props.maxWidth) {
@@ -899,7 +898,7 @@ elCanvas = (function () {
 				}
 				el.ctx.fillText(props.text, 0, 0, maxWidth);
 			},
-			shape: function (el, props){
+			shape: function (el, props) {
 				var func = (typeof props.customShape == "function") ? props.customShape : el.customShapes[props.customShape];
 				if (typeof func == "function") {
 					func(el);
@@ -908,7 +907,7 @@ elCanvas = (function () {
 					console.log("custom shape function missing", props.customShape, el.customShapes);
 				}
 			},
-			svg: function (el, props){
+			svg: function (el, props) {
 				if (props.__cachedPoints !== props.points) {
 					//rebuild points only if the supplied are new points
 					props.__cachedFunction = _util.parseSvgPathData(props, el.ctx);
@@ -916,12 +915,12 @@ elCanvas = (function () {
 					// now assign the old points to be the new points so we dont need to repeat this function
 					props.__cachedPoints = props.points;
 				}
-        //add line dash if youve declared it in styles
-        props.style.setLineDash ? el.ctx.setLineDash(props.style.setLineDash.split(',').map(Number)) : false;
-        props.style.lineDashOffset ? el.ctx.set('lineDashOffset',props.style.lineDashOffset) : false;
+				//add line dash if youve declared it in styles
+				props.style.setLineDash && el.ctx.setLineDash(props.style.setLineDash.split(',').map(Number));
+				props.style.lineDashOffset && el.ctx.set('lineDashOffset',props.style.lineDashOffset);
 
 				props.__cachedFunction();
-				el.fillAndStroke(props) ;
+				el.fillAndStroke(props);
 			}
 		},
 		/**


### PR DESCRIPTION
Fixes to consistent code style (use && instead of ternary as "if" shortcut), and formatting (indent with tabs, spacing issues)
